### PR TITLE
Add pairing & QR code API routes

### DIFF
--- a/api/paircode1.js
+++ b/api/paircode1.js
@@ -1,0 +1,11 @@
+export default function handler(req, res) {
+  res.status(200).send(`
+    <html>
+      <head><title>Pair Code 1</title></head>
+      <body style="text-align:center;font-family:sans-serif;">
+        <h2>🔐 Pair Code 1</h2>
+        <p>Coming soon... BeltahBot pairing system will display code here.</p>
+      </body>
+    </html>
+  `);
+}

--- a/api/paircode2.js
+++ b/api/paircode2.js
@@ -1,0 +1,11 @@
+export default function handler(req, res) {
+  res.status(200).send(`
+    <html>
+      <head><title>Pair Code 2</title></head>
+      <body style="text-align:center;font-family:sans-serif;">
+        <h2>🔐 Pair Code 2</h2>
+        <p>This page will show the second pairing code soon.</p>
+      </body>
+    </html>
+  `);
+}

--- a/api/scanqr1.js
+++ b/api/scanqr1.js
@@ -1,0 +1,11 @@
+export default function handler(req, res) {
+  res.status(200).send(`
+    <html>
+      <head><title>Scan QR 1</title></head>
+      <body style="text-align:center;font-family:sans-serif;">
+        <h2>📸 Scan QR 1</h2>
+        <p>This QR will be generated and shown here once setup is complete.</p>
+      </body>
+    </html>
+  `);
+}

--- a/api/scanqr2.js
+++ b/api/scanqr2.js
@@ -1,0 +1,11 @@
+export default function handler(req, res) {
+  res.status(200).send(`
+    <html>
+      <head><title>Scan QR 2</title></head>
+      <body style="text-align:center;font-family:sans-serif;">
+        <h2>📸 Scan QR 2</h2>
+        <p>Another QR page. Coming soon with full WhatsApp pairing!</p>
+      </body>
+    </html>
+  `);
+}


### PR DESCRIPTION
This PR adds the /api routes for:

- ✅ Pair Code 1 (`/api/paircode1`)
- ✅ Pair Code 2 (`/api/paircode2`)
- ✅ Scan QR 1 (`/api/scanqr1`)
- ✅ Scan QR 2 (`/api/scanqr2`)

These will stop 404 errors and complete the pairing UI flow.